### PR TITLE
fix: fixes issues when using the Astro `base` option

### DIFF
--- a/packages/astro-d2/config.ts
+++ b/packages/astro-d2/config.ts
@@ -3,14 +3,6 @@ import { z } from 'astro/zod'
 export const AstroD2ConfigSchema = z
   .object({
     /**
-     * The base path to use website.
-     *
-     * This is useful when you want to serve the astro website from a subdirectory.
-     *
-     * @default ''
-     */
-    basePath: z.string().default(''),
-    /**
      * Defines the layout engine to use to generate the diagrams.
      *
      * @default 'dagre'

--- a/packages/astro-d2/config.ts
+++ b/packages/astro-d2/config.ts
@@ -3,6 +3,14 @@ import { z } from 'astro/zod'
 export const AstroD2ConfigSchema = z
   .object({
     /**
+     * The base path to use website.
+     *
+     * This is useful when you want to serve the astro website from a subdirectory.
+     *
+     * @default ''
+     */
+    basePath: z.string().default(''),
+    /**
      * Defines the layout engine to use to generate the diagrams.
      *
      * @default 'dagre'

--- a/packages/astro-d2/index.ts
+++ b/packages/astro-d2/index.ts
@@ -24,7 +24,7 @@ export default function astroD2Integration(userConfig?: AstroD2UserConfig): Astr
   return {
     name: 'astro-d2-integration',
     hooks: {
-      'astro:config:setup': async ({ command, logger, updateConfig }) => {
+      'astro:config:setup': async ({ command, config: astroConfig, logger, updateConfig }) => {
         if (command !== 'build' && command !== 'dev') {
           return
         }
@@ -45,7 +45,7 @@ export default function astroD2Integration(userConfig?: AstroD2UserConfig): Astr
 
         updateConfig({
           markdown: {
-            remarkPlugins: [[remarkAstroD2, config]],
+            remarkPlugins: [[remarkAstroD2, { ...config, base: astroConfig.base }]],
           },
         })
       },

--- a/packages/astro-d2/libs/remark.ts
+++ b/packages/astro-d2/libs/remark.ts
@@ -10,7 +10,7 @@ import { type DiagramAttributes, getAttributes } from './attributes'
 import { generateD2Diagram, type D2Size, getD2DiagramSize } from './d2'
 import { throwErrorWithHint } from './integration'
 
-export function remarkAstroD2(config: AstroD2Config) {
+export function remarkAstroD2(config: RemarkAstroD2Config) {
   return async function transformer(tree: Root, file: VFile) {
     const d2Nodes: [node: Code, context: VisitorContext][] = []
 
@@ -70,7 +70,7 @@ function makHtmlImgNode(attributes: DiagramAttributes, imgPath: string, size: D2
   }
 }
 
-function getOutputPaths(config: AstroD2Config, file: VFile, nodeIndex: number) {
+function getOutputPaths(config: RemarkAstroD2Config, file: VFile, nodeIndex: number) {
   const relativePath = path.relative(file.cwd, file.path).replace(/^src\/(content|pages)\//, '')
   const parsedRelativePath = path.parse(relativePath)
 
@@ -78,7 +78,7 @@ function getOutputPaths(config: AstroD2Config, file: VFile, nodeIndex: number) {
 
   return {
     fsPath: path.join(file.cwd, 'public', config.output, relativeOutputPath),
-    imgPath: path.posix.join('/', config.basePath, config.output, relativeOutputPath),
+    imgPath: path.posix.join(config.base, config.output, relativeOutputPath),
   }
 }
 
@@ -99,4 +99,8 @@ function computeImgSize(htmlAttributes: Record<string, string>, attributes: Diag
 interface VisitorContext {
   index: number | undefined
   parent: Parent | undefined
+}
+
+interface RemarkAstroD2Config extends AstroD2Config {
+  base: string
 }

--- a/packages/astro-d2/libs/remark.ts
+++ b/packages/astro-d2/libs/remark.ts
@@ -78,7 +78,7 @@ function getOutputPaths(config: AstroD2Config, file: VFile, nodeIndex: number) {
 
   return {
     fsPath: path.join(file.cwd, 'public', config.output, relativeOutputPath),
-    imgPath: path.posix.join('/', config.output, relativeOutputPath),
+    imgPath: path.posix.join('/', config.basePath, config.output, relativeOutputPath),
   }
 }
 

--- a/packages/astro-d2/tests/remark.test.ts
+++ b/packages/astro-d2/tests/remark.test.ts
@@ -9,7 +9,7 @@ import { AstroD2ConfigSchema, type AstroD2UserConfig } from '../config'
 import { exec } from '../libs/exec'
 import { remarkAstroD2 } from '../libs/remark'
 
-const defaultProcessor = remark().use(remarkAstroD2, AstroD2ConfigSchema.parse({}))
+const defaultProcessor = remark().use(remarkAstroD2, { ...AstroD2ConfigSchema.parse({}), base: '/' })
 const defaultDiagram = 'x -> y'
 const defaultMd = `\`\`\`d2
 ${defaultDiagram}
@@ -180,8 +180,19 @@ ${defaultDiagram}
   `)
 })
 
-async function transformMd(md: string, userConfig?: AstroD2UserConfig) {
-  const processor = userConfig ? remark().use(remarkAstroD2, AstroD2ConfigSchema.parse(userConfig)) : defaultProcessor
+test('uses the specified base option', async () => {
+  const result = await transformMd(defaultMd, {}, '/test')
+
+  expect(result).toMatchInlineSnapshot(`
+    "<img alt="Diagram" decoding="async" loading="lazy" src="/test/d2/tests/index-0.svg" width="128" height="64" />
+    "
+  `)
+})
+
+async function transformMd(md: string, userConfig?: AstroD2UserConfig, base = '/') {
+  const processor = userConfig
+    ? remark().use(remarkAstroD2, { ...AstroD2ConfigSchema.parse(userConfig), base })
+    : defaultProcessor
 
   const file = await processor.process(
     new VFile({


### PR DESCRIPTION
Add an option to add the astro base path for static content.

**Why**

When the astro website is served from a subfolder the image path was incorrect.

**How**

Added a new optional config parameter.