### PR TITLE
fix: improves D2 version detection logic

### DIFF
--- a/packages/astro-d2/libs/d2.ts
+++ b/packages/astro-d2/libs/d2.ts
@@ -85,7 +85,7 @@ async function getD2Version() {
   try {
     const [version] = await exec('d2', ['--version'])
 
-    if (!version || !/^\d+\.\d+\.\d+$/.test(version)) {
+    if (!version || !/^v?\d+\.\d+\.\d+$/.test(version)) {
       throw new Error(`Invalid D2 version, got '${version}'.`)
     }
 

--- a/packages/astro-d2/libs/d2.ts
+++ b/packages/astro-d2/libs/d2.ts
@@ -85,7 +85,7 @@ async function getD2Version() {
   try {
     const [version] = await exec('d2', ['--version'])
 
-    if (!version || !/^v?\d+\.\d+\.\d+$/.test(version)) {
+    if (!version || !/^v?\d+\.\d+\.\d+/.test(version)) {
       throw new Error(`Invalid D2 version, got '${version}'.`)
     }
 


### PR DESCRIPTION
**Describe the pull request**

see title

**Why**

Fixes #3 

**How**

adds an optional 'v' at the beginning of the regexp that checks the d2 version


<!-- Feel free to add additional comments. -->
It might also be helpful to remove the '$' at the end or replace it with '.*$' for the case that d2 uses patterns like 'v0.6.3-HEAD' or similar.  