### PR TITLE
feat: add new `sketch` and `pad` global configuration options applicable to all diagrams

### DIFF
--- a/docs/src/content/docs/attributes.md
+++ b/docs/src/content/docs/attributes.md
@@ -78,10 +78,9 @@ See the D2 documentation for more information about the available [themes](https
 
 ### `sketch`
 
-**Default:** `'false'`  
 **Example**: [Sketch attribute](/examples/attributes/sketch/)
 
-Whether to render the diagram as if it was sketched by hand.
+Overrides the [global `sketch` configuration](/configuration/#sketch) and defines whether to render the diagram as if it was sketched by hand.
 
 ````md title="src/content/docs/example.md" "sketch"
 ```d2 sketch
@@ -91,10 +90,9 @@ x -> y
 
 ### `pad`
 
-**Default:** `'100'`  
 **Example**: [Padding attribute](/examples/attributes/padding/)
 
-The padding (in pixels) around the rendered diagram.
+Overrides the [global `pad` configuration](/configuration/#pad) and defines the padding (in pixels) around the rendered diagram.
 
 ````md title="src/content/docs/example.md" "pad=10"
 ```d2 pad=10

--- a/docs/src/content/docs/configuration.md
+++ b/docs/src/content/docs/configuration.md
@@ -54,6 +54,20 @@ This will require you to [build](https://docs.astro.build/en/reference/cli-refer
 Defines the layout engine to use to generate the diagrams.
 See the D2 documentation for more information about the available [layout engines](https://d2lang.com/tour/layouts#layout-engines).
 
+### `sketch`
+
+**Type:** `boolean`  
+**Default:** `false`
+
+Whether to render the diagrams as if they were sketched by hand.
+
+### `pad`
+
+**Type:** `number`  
+**Default:** `100`
+
+The padding (in pixels) around the rendered diagrams.
+
 ---
 
 ## Theme configuration

--- a/packages/astro-d2/config.ts
+++ b/packages/astro-d2/config.ts
@@ -16,13 +16,13 @@ export const AstroD2ConfigSchema = z
      */
     output: z.string().default('d2'),
     /**
-     * Defines the default pad value for all diagrams.
+     * The padding (in pixels) around the rendered diagrams.
      *
      * @default 100
      */
     pad: z.number().default(100),
     /**
-     * Whether the Astro D2 integration should default to render the diagram as if sketched by hand.
+     * Whether to render the diagrams as if they were sketched by hand.
      *
      * @default false
      */

--- a/packages/astro-d2/config.ts
+++ b/packages/astro-d2/config.ts
@@ -16,6 +16,18 @@ export const AstroD2ConfigSchema = z
      */
     output: z.string().default('d2'),
     /**
+     * Defines the default pad value for all diagrams.
+     *
+     * @default 100
+     */
+    pad: z.number().default(100),
+    /**
+     * Whether the Astro D2 integration should default to render the diagram as if sketched by hand.
+     *
+     * @default false
+     */
+    sketch: z.boolean().default(false),
+    /**
      * Whether the Astro D2 integration should skip the generation of diagrams.
      *
      * This is useful to disable generating diagrams when deploying on platforms that do not have the D2 binary

--- a/packages/astro-d2/libs/attributes.ts
+++ b/packages/astro-d2/libs/attributes.ts
@@ -23,13 +23,13 @@ export const AttributesSchema = z
      *
      * @default 100
      */
-    pad: z.coerce.number().default(100),
+    pad: z.coerce.string().optional(),
     /**
      * Whether to render the diagram as if it was sketched by hand.
      *
      * @default 'false'
      */
-    sketch: z.union([z.literal('true'), z.literal('false')]).default('false'),
+    sketch: z.union([z.literal('true'), z.literal('false')]).optional(),
     /**
      * Defines the target board to render when using composition.
      * Use `root` to target the root board.

--- a/packages/astro-d2/libs/attributes.ts
+++ b/packages/astro-d2/libs/attributes.ts
@@ -19,17 +19,16 @@ export const AttributesSchema = z
       .optional()
       .transform((value) => (value === 'false' ? false : value)),
     /**
-     * The padding (in pixels) around the rendered diagram.
-     *
-     * @default 100
+     * Overrides the global `pad` configuration for the diagram.
      */
-    pad: z.coerce.string().optional(),
+    pad: z.coerce.number().optional(),
     /**
-     * Whether to render the diagram as if it was sketched by hand.
-     *
-     * @default 'false'
+     * Overrides the global `sketch` configuration for the diagram.
      */
-    sketch: z.union([z.literal('true'), z.literal('false')]).optional(),
+    sketch: z
+      .union([z.literal('true'), z.literal('false')])
+      .optional()
+      .transform((value) => (value === 'false' ? false : value)),
     /**
      * Defines the target board to render when using composition.
      * Use `root` to target the root board.

--- a/packages/astro-d2/libs/d2.ts
+++ b/packages/astro-d2/libs/d2.ts
@@ -40,6 +40,14 @@ export async function generateD2Diagram(
     extraArgs.push(`--target='${attributes.target}'`)
   }
 
+  if (attributes.sketch !== undefined) {
+    extraArgs.push(`--sketch=${attributes.sketch}`)
+  }
+
+  if (attributes.pad !== undefined) {
+    extraArgs.push(`--pad=${attributes.pad}`)
+  }
+
   try {
     // The `-` argument is used to read from stdin instead of a file.
     await exec(
@@ -47,8 +55,8 @@ export async function generateD2Diagram(
       [
         `--layout=${config.layout}`,
         `--theme=${attributes.theme ?? config.theme.default}`,
-        `--sketch=${attributes.sketch}`,
-        `--pad=${attributes.pad}`,
+        `--sketch=${attributes.sketch ?? config.sketch}`,
+        `--pad=${attributes.pad ?? config.pad}`,
         ...extraArgs,
         '-',
         outputPath,

--- a/packages/astro-d2/libs/d2.ts
+++ b/packages/astro-d2/libs/d2.ts
@@ -40,14 +40,6 @@ export async function generateD2Diagram(
     extraArgs.push(`--target='${attributes.target}'`)
   }
 
-  if (attributes.sketch !== undefined) {
-    extraArgs.push(`--sketch=${attributes.sketch}`)
-  }
-
-  if (attributes.pad !== undefined) {
-    extraArgs.push(`--pad=${attributes.pad}`)
-  }
-
   try {
     // The `-` argument is used to read from stdin instead of a file.
     await exec(

--- a/packages/astro-d2/tests/attributes.test.ts
+++ b/packages/astro-d2/tests/attributes.test.ts
@@ -58,6 +58,12 @@ test('supports a shorthand syntax for `sketch`', () => {
   expect(attributes).toEqual({ ...defaultAttributes, sketch: 'true' })
 })
 
+test('transforms the `sketch` value to a boolean if set to `false`', () => {
+  const attributes = getAttributes('sketch=false')
+
+  expect(attributes).toEqual({ ...defaultAttributes, sketch: false })
+})
+
 test('supports coersed number for `pad` and `width`', () => {
   const attributes = getAttributes('pad=50 width=100')
 

--- a/packages/astro-d2/tests/remark.test.ts
+++ b/packages/astro-d2/tests/remark.test.ts
@@ -141,6 +141,15 @@ ${defaultDiagram}
   expectD2ToHaveBeenCalledWithArg('--sketch=true')
 })
 
+test('disables the `sketch` attribute if specified', async () => {
+  await transformMd(`\`\`\`d2 sketch=false
+${defaultDiagram}
+\`\`\`
+`)
+
+  expectD2ToHaveBeenCalledWithArg('--sketch=false')
+})
+
 test('uses the `pad` attribute if specified', async () => {
   await transformMd(`\`\`\`d2 pad=50
 ${defaultDiagram}
@@ -222,8 +231,8 @@ function expectD2ToHaveBeenNthCalledWith(
     [
       `--layout=${config.layout}`,
       `--theme=${config.theme.default}`,
-      `--sketch=false`,
-      `--pad=100`,
+      `--sketch=${config.sketch}`,
+      `--pad=${config.pad}`,
       `--dark-theme=${config.theme.dark}`,
       '-',
       fileURLToPath(new URL(`../public/${config.output}/tests/index-${diagramIndex}.svg`, import.meta.url)),

--- a/packages/astro-d2/tests/remark.test.ts
+++ b/packages/astro-d2/tests/remark.test.ts
@@ -133,6 +133,15 @@ ${defaultDiagram}
 })
 
 test('uses the `sketch` attribute if specified', async () => {
+  await transformMd(`\`\`\`d2 sketch=true
+${defaultDiagram}
+\`\`\`
+`)
+
+  expectD2ToHaveBeenCalledWithArg('--sketch=true')
+})
+
+test('uses the `sketch` shorthand attribute if specified', async () => {
   await transformMd(`\`\`\`d2 sketch
 ${defaultDiagram}
 \`\`\`
@@ -141,13 +150,32 @@ ${defaultDiagram}
   expectD2ToHaveBeenCalledWithArg('--sketch=true')
 })
 
-test('disables the `sketch` attribute if specified', async () => {
-  await transformMd(`\`\`\`d2 sketch=false
+test('uses the `sketch` attribute to disable the `sketch` config if specified', async () => {
+  const config = { sketch: true }
+
+  await transformMd(
+    `\`\`\`d2 sketch=false
 ${defaultDiagram}
 \`\`\`
-`)
+`,
+    config,
+  )
 
   expectD2ToHaveBeenCalledWithArg('--sketch=false')
+})
+
+test('uses the `sketch` attribute to enable the `sketch` config if specified', async () => {
+  const config = { sketch: false }
+
+  await transformMd(
+    `\`\`\`d2 sketch
+${defaultDiagram}
+\`\`\`
+`,
+    config,
+  )
+
+  expectD2ToHaveBeenCalledWithArg('--sketch=true')
 })
 
 test('uses the `pad` attribute if specified', async () => {
@@ -157,6 +185,20 @@ ${defaultDiagram}
 `)
 
   expectD2ToHaveBeenCalledWithArg('--pad=50')
+})
+
+test('uses the `pad` attribute to override the `pad` config if specified', async () => {
+  const config = { pad: 200 }
+
+  await transformMd(
+    `\`\`\`d2 pad=25
+${defaultDiagram}
+\`\`\`
+`,
+    config,
+  )
+
+  expectD2ToHaveBeenCalledWithArg('--pad=25')
 })
 
 test('uses the `animateInterval` attribute if specified', async () => {


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
Please provide as much details as possible, including screenshots or sample code if necessary.
-->

**Describe the pull request**

Add `sketch` and `pad` values to the global config.

**Why**

So that I do not need to manually add `sketch=true` to every `d2` code block if I want my website to use sketch style by default. The same for padding.

**How**

I updated the handling of attributes and added new `sketch` and `pad` config options. Plus, I added a test but I'm not sure I did that correctly.

**Screenshots**

If applicable, add screenshots to help explain what is being modified.

<!-- Feel free to add additional comments. -->

I want to note that I removed the default pad and perhaps you want to return that value to 100.