### PR TITLE
Fix package root entrypoint to publish compiled JS

### DIFF
--- a/.changeset/clean-d2-package.md
+++ b/.changeset/clean-d2-package.md
@@ -1,0 +1,5 @@
+---
+"astro-d2": patch
+---
+
+Publish the package entrypoint as compiled JavaScript with declaration files.

--- a/packages/astro-d2/index.ts
+++ b/packages/astro-d2/index.ts
@@ -4,13 +4,13 @@ import path from 'node:path'
 import type { AstroIntegration } from 'astro'
 import { z } from 'astro/zod'
 
-import { AstroD2ConfigSchema, type AstroD2UserConfig } from './config'
-import { clearContentLayerCache } from './libs/astro'
-import { isD2BinaryInstalled } from './libs/d2'
-import { throwErrorWithHint } from './libs/integration'
-import { remarkAstroD2 } from './libs/remark'
+import { AstroD2ConfigSchema, type AstroD2UserConfig } from './config.js'
+import { clearContentLayerCache } from './libs/astro.js'
+import { isD2BinaryInstalled } from './libs/d2.js'
+import { throwErrorWithHint } from './libs/integration.js'
+import { remarkAstroD2 } from './libs/remark.js'
 
-export type { AstroD2UserConfig } from './config'
+export type { AstroD2UserConfig } from './config.js'
 
 export default function astroD2Integration(userConfig?: AstroD2UserConfig): AstroIntegration {
   const parsedConfig = AstroD2ConfigSchema.safeParse(userConfig)

--- a/packages/astro-d2/libs/d2.ts
+++ b/packages/astro-d2/libs/d2.ts
@@ -4,9 +4,9 @@ import url from 'node:url'
 
 import { D2, type CompileRequest } from '@terrastruct/d2'
 
-import type { DiagramAttributes } from './attributes'
-import { exec } from './exec'
-import type { RemarkAstroD2Config } from './remark'
+import type { DiagramAttributes } from './attributes.js'
+import { exec } from './exec.js'
+import type { RemarkAstroD2Config } from './remark.js'
 
 const viewBoxRegex = /viewBox="\d+ \d+ (?<width>\d+) (?<height>\d+)"/
 

--- a/packages/astro-d2/libs/remark.ts
+++ b/packages/astro-d2/libs/remark.ts
@@ -9,11 +9,11 @@ import type { Code, Html, Parent, Root } from 'mdast'
 import { CONTINUE, EXIT, SKIP, visit } from 'unist-util-visit'
 import type { VFile } from 'vfile'
 
-import type { AstroD2Config } from '../config'
+import type { AstroD2Config } from '../config.js'
 
-import { type DiagramAttributes, getAttributes } from './attributes'
-import { generateD2Diagram, type D2Size, getD2Diagram, type D2Diagram } from './d2'
-import { throwErrorWithHint } from './integration'
+import { type DiagramAttributes, getAttributes } from './attributes.js'
+import { generateD2Diagram, type D2Size, getD2Diagram, type D2Diagram } from './d2.js'
+import { throwErrorWithHint } from './integration.js'
 
 export function remarkAstroD2(config: RemarkAstroD2Config) {
   return async function transformer(tree: Root, file: VFile) {

--- a/packages/astro-d2/package.json
+++ b/packages/astro-d2/package.json
@@ -5,11 +5,20 @@
   "description": "Astro integration and remark plugin to transform D2 Markdown code blocks into diagrams.",
   "author": "HiDeoo <github@hideoo.dev> (https://hideoo.dev)",
   "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./index.ts",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
     "./package.json": "./package.json"
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
     "test": "vitest",
     "lint": "eslint . --cache --max-warnings=0"
   },

--- a/packages/astro-d2/tsconfig.build.json
+++ b/packages/astro-d2/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "incremental": false,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["index.ts", "config.ts", "libs/**/*.ts"],
+  "exclude": ["dist", "tests"]
+}


### PR DESCRIPTION
## Summary

- publish the package root from compiled JavaScript in `dist/index.js`
- emit declaration files into `dist`
- add a package build script and build tsconfig
- update internal relative imports to ESM-compatible `.js` specifiers
- add a patch changeset

## Why

`astro-d2@0.11.0` currently publishes the package root as `./index.ts`:

```json
"exports": {
  ".": "./index.ts"
}
```

In a clean Node project, importing the published package fails because Node does not strip TypeScript from files under `node_modules`:

```text
Error [ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING]: Stripping types is currently unsupported for files under node_modules, for ".../node_modules/astro-d2/index.ts"
```

This PR keeps the same public root export, but points consumers at compiled JavaScript and declaration files.

## Validation

- `corepack pnpm@10.32.1 --filter astro-d2 build`
- `corepack pnpm@10.32.1 --filter astro-d2 lint`
- `node --input-type=module -e "import('./packages/astro-d2/dist/index.js').then(m=>console.log(typeof m.default))"` -> `function`
- `npm pack --dry-run --json --ignore-scripts ./packages/astro-d2` now includes only package metadata/README plus compiled `dist/*.js` and `dist/*.d.ts` files for the runtime entrypoint

I also ran `corepack pnpm@10.32.1 --filter astro-d2 test` before this change. On this Windows machine it already fails due to existing snapshot expectations using POSIX separators and LF fixture text while the test run receives Windows `\` separators and CRLF fixture text. The failures are unrelated to the packaging change.
